### PR TITLE
Use remote ip for peer ip

### DIFF
--- a/lib/oidcc/plug/authorization_callback.ex
+++ b/lib/oidcc/plug/authorization_callback.ex
@@ -87,7 +87,7 @@ defmodule Oidcc.Plug.AuthorizationCallback do
   alias Oidcc.Userinfo
 
   import Plug.Conn,
-    only: [get_session: 2, delete_session: 2, put_private: 3, get_peer_data: 1, get_req_header: 2]
+    only: [get_session: 2, delete_session: 2, put_private: 3, get_req_header: 2]
 
   import Oidcc.Plug.Config, only: [evaluate_config: 1]
 
@@ -255,13 +255,8 @@ defmodule Oidcc.Plug.AuthorizationCallback do
   defp check_peer_ip(conn, peer_ip, check_peer_ip?)
   defp check_peer_ip(_conn, _peer_ip, false), do: :ok
   defp check_peer_ip(_conn, nil, true), do: :ok
-
-  defp check_peer_ip(%Plug.Conn{} = conn, peer_ip, true) do
-    case get_peer_data(conn) do
-      %{address: ^peer_ip} -> :ok
-      %{} -> {:error, :peer_ip_mismatch}
-    end
-  end
+  defp check_peer_ip(%Plug.Conn{remote_ip: peer_ip}, peer_ip, true), do: :ok
+  defp check_peer_ip(%Plug.Conn{}, _peer_ip, true), do: {:error, :peer_ip_mismatch}
 
   @spec check_useragent(
           conn :: Plug.Conn.t(),

--- a/lib/oidcc/plug/authorize.ex
+++ b/lib/oidcc/plug/authorize.ex
@@ -31,7 +31,7 @@ defmodule Oidcc.Plug.Authorize do
   alias Oidcc.ClientContext
 
   import Plug.Conn,
-    only: [send_resp: 3, put_resp_header: 3, put_session: 3, get_peer_data: 1, get_req_header: 2]
+    only: [send_resp: 3, put_resp_header: 3, put_session: 3, get_req_header: 2]
 
   import Oidcc.Plug.Config, only: [evaluate_config: 1]
 
@@ -104,8 +104,7 @@ defmodule Oidcc.Plug.Authorize do
     nonce = 31 |> :crypto.strong_rand_bytes() |> Base.url_encode64(padding: false)
     pkce_verifier = 96 |> :crypto.strong_rand_bytes() |> Base.url_encode64(padding: false)
 
-    %{address: peer_ip} = get_peer_data(conn)
-
+    peer_ip = conn.remote_ip
     useragent = conn |> get_req_header("User-Agent") |> List.first()
 
     authorization_opts =

--- a/test/oidcc/plug/authorization_callback_test.exs
+++ b/test/oidcc/plug/authorization_callback_test.exs
@@ -1,8 +1,9 @@
 defmodule Oidcc.Plug.AuthorizationCallbackTest do
   use ExUnit.Case, async: false
-  use Plug.Test
 
   import Mock
+  import Plug.Test
+  import Plug.Conn
 
   alias Oidcc.ClientContext
   alias Oidcc.Plug.AuthorizationCallback

--- a/test/oidcc/plug/authorization_callback_test.exs
+++ b/test/oidcc/plug/authorization_callback_test.exs
@@ -42,7 +42,7 @@ defmodule Oidcc.Plug.AuthorizationCallbackTest do
     :ok
   end
 
-  describe inspect(&Authorize.call/2) do
+  describe inspect(&AuthorizationCallback.call/2) do
     test "successful retrieve" do
       with_mocks [
         {Oidcc.Token, [],
@@ -178,6 +178,55 @@ defmodule Oidcc.Plug.AuthorizationCallbackTest do
                })
                |> put_req_header("user-agent", "useragent")
                |> AuthorizationCallback.call(opts)
+    end
+
+    test "peer_ip match on remote_ip only" do
+      with_mocks [
+        {Oidcc.Token, [],
+         retrieve: fn "code",
+                      _client_context,
+                      %{
+                        redirect_uri: "http://localhost:8080/oidc/return",
+                        nonce: _nonce,
+                        refresh_jwks: _refresh_fun
+                      } ->
+           {:ok, :token}
+         end}
+      ] do
+        opts =
+          AuthorizationCallback.init(
+            provider: ProviderName,
+            client_id: fn -> "client_id" end,
+            client_secret: "client_secret",
+            redirect_uri: "http://localhost:8080/oidc/return",
+            retrieve_userinfo: false
+          )
+
+        conn =
+          "get"
+          |> conn("/", %{"code" => "code"})
+          |> put_req_header("x-forwarded-for", "10.0.0.1")
+          |> Plug.RewriteOn.call(Plug.RewriteOn.init([:x_forwarded_for]))
+
+        assert %{
+                 halted: false,
+                 private: %{
+                   Oidcc.Plug.AuthorizationCallback => {:ok, {:token, nil}}
+                 }
+               } =
+                 conn
+                 |> Plug.Test.init_test_session(%{
+                   Authorize.get_session_name() => %{
+                     nonce: "nonce",
+                     peer_ip: {10, 0, 0, 1},
+                     useragent: "useragent",
+                     pkce_verifier: "pkce_verifier",
+                     state_verifier: 0
+                   }
+                 })
+                 |> put_req_header("user-agent", "useragent")
+                 |> AuthorizationCallback.call(opts)
+      end
     end
 
     test "allows mismatch if disabled" do

--- a/test/oidcc/plug/authorize_test.exs
+++ b/test/oidcc/plug/authorize_test.exs
@@ -1,8 +1,9 @@
 defmodule Oidcc.Plug.AuthorizeTest do
   use ExUnit.Case, async: false
-  use Plug.Test
 
   import Mock
+  import Plug.Test
+  import Plug.Conn
 
   alias Oidcc.ClientContext
   alias Oidcc.Plug.Authorize

--- a/test/oidcc/plug/extract_authorization_test.exs
+++ b/test/oidcc/plug/extract_authorization_test.exs
@@ -1,6 +1,8 @@
 defmodule Oidcc.Plug.ExtractAuthorizationTest do
   use ExUnit.Case, async: true
-  use Plug.Test
+
+  import Plug.Test
+  import Plug.Conn
 
   alias Oidcc.Plug.ExtractAuthorization
 

--- a/test/oidcc/plug/introspect_token_test.exs
+++ b/test/oidcc/plug/introspect_token_test.exs
@@ -1,8 +1,9 @@
 defmodule Oidcc.Plug.IntrospectTokenTest do
   use ExUnit.Case, async: false
-  use Plug.Test
 
   import Mock
+  import Plug.Test
+  import Plug.Conn
 
   alias Oidcc.Plug.ExtractAuthorization
   alias Oidcc.Plug.IntrospectToken

--- a/test/oidcc/plug/load_userinfo_test.exs
+++ b/test/oidcc/plug/load_userinfo_test.exs
@@ -1,8 +1,9 @@
 defmodule Oidcc.Plug.LoadUserinfoTest do
   use ExUnit.Case, async: false
-  use Plug.Test
 
   import Mock
+  import Plug.Test
+  import Plug.Conn
 
   alias Oidcc.Plug.ExtractAuthorization
   alias Oidcc.Plug.LoadUserinfo

--- a/test/oidcc/plug/require_authorization.exs
+++ b/test/oidcc/plug/require_authorization.exs
@@ -1,6 +1,8 @@
 defmodule Oidcc.Plug.RequireAuthorizationTest do
   use ExUnit.Case, async: false
-  use Plug.Test
+
+  import Plug.Test
+  import Plug.Conn
 
   alias Oidcc.Plug.ExtractAuthorization
   alias Oidcc.Plug.RequireAuthorization

--- a/test/oidcc/plug/validate_jwt_token_test.exs
+++ b/test/oidcc/plug/validate_jwt_token_test.exs
@@ -1,8 +1,9 @@
 defmodule Oidcc.Plug.ValidateJwtTokenTest do
   use ExUnit.Case, async: false
-  use Plug.Test
 
   import Mock
+  import Plug.Test
+  import Plug.Conn
 
   alias Oidcc.Plug.ExtractAuthorization
   alias Oidcc.Plug.ValidateJwtToken


### PR DESCRIPTION
<!---
name: 🐞 Bug Fix
about: You have a fix for a bug?
labels: bug
--->

Fixes #34.

Use the conn `:remote_ip` instead of data gotten through `Plug.Conn.get_peer_data/1`.
This allows to take into account proxies, whilst keeping the remote peer ip as default.

Take the opportunity to replace `use Plug.Test` by `imports`.
