### PR TITLE
fix a small typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,12 @@ setup for phoenix:
 mix igniter.new test \
   --install phoenix,oidcc,oidcc_plug \
   --with phx.new
-  
+
 # Add Igniter Phoenix Extension
 mix igniter.add_extension phoenix
 
 # Generate Provider, Controller, Router & Config
-mix oidcc.gen.controller \
+mix oidcc_plug.gen.controller \
     --name MyApp.AuthController \
     --provider MyApp.OpenIDProvider \
     --base-url /auth \

--- a/lib/mix/tasks/oidcc_plug.gen.controller.ex
+++ b/lib/mix/tasks/oidcc_plug.gen.controller.ex
@@ -1,7 +1,7 @@
 short_doc = "Generate an auth controller for your OpenID provider"
 
 example = """
-mix oidcc.gen.controller \\
+mix oidcc_plug.gen.controller \\
   --name MyApp.AuthController \\
   --provider MyApp.OpenIDProvider \\
   --base-url /auth \\


### PR DESCRIPTION
<!---
name: 🐞 Bug Fix (documentation)
about: Just a small typo in the mix task documentation
labels: bug
--->

<!--
- Please target the oldest branch of oidcc that is still supported and
  affected by this bug.
-->
