### PR TITLE
Relax `:igniter` dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -71,7 +71,7 @@ defmodule Oidcc.Plug.MixProject do
       {:dialyxir, "~> 1.4", only: :dev, runtime: false},
       {:ex_doc, "~> 0.29", only: :dev, runtime: false},
       {:excoveralls, "~> 0.18.1", only: :test, runtime: false},
-      {:igniter, "~> 0.5.50", optional: true},
+      {:igniter, "~> 0.5", optional: true},
       {:mock, "~> 0.3.8", only: :test},
       {:oidcc, "~> 3.5"},
       {:phoenix, "~> 1.7", only: [:dev, :test]},


### PR DESCRIPTION
<!---
name: 🐞 Bug Fix
about: You have a fix for a bug?
labels: bug
--->

Having a too specific version of `:igniter` as requirement prevents projects depending on `:igniter` from updating it to its latest version.
According to [Elixir's Library guidelines](https://hexdocs.pm/elixir/1.19.0-rc.0/library-guidelines.html#dependency-version-requirements), libraries should avoid being too specific on their dependencies version.

Relax Igniter version, from ~> 0.5.50 to ~> 0.5.

<!--
- Please target the oldest branch of oidcc that is still supported and
  affected by this bug.
-->
